### PR TITLE
FIX: remove compound selector from @extend

### DIFF
--- a/assets/stylesheets/common/multilingual/content-language-tags.scss
+++ b/assets/stylesheets/common/multilingual/content-language-tags.scss
@@ -30,7 +30,7 @@
   }
 
   .content-language-tag {
-    @extend .discourse-tag.simple;
+    @extend .discourse-tag;
   }
 }
 


### PR DESCRIPTION
this is no longer supported in sass